### PR TITLE
Escape braces in perl regex

### DIFF
--- a/data/word_embeddings/wikifil.pl
+++ b/data/word_embeddings/wikifil.pl
@@ -31,8 +31,8 @@ while (<>) {
     s/\[\[category:([^|\]]*)[^]]*\]\]/[[$1]]/ig;  # show categories without markup
     s/\[\[[a-z\-]*:[^\]]*\]\]//g;  # remove links to other languages
     s/\[\[[^\|\]]*\|/[[/g;  # remove wiki url, preserve visible text
-    s/{{[^}]*}}//g;         # remove {{icons}} and {tables}
-    s/{[^}]*}//g;
+    s/\{\{[^\}]*\}\}//g;    # remove {{icons}} and {tables}
+    s/\{[^\}]*\}//g;
     s/\[//g;                # remove [ and ]
     s/\]//g;
     s/&[^;]*;/ /g;          # remove URL encoded chars


### PR DESCRIPTION
`fetch_all_data.sh` failed to get Wikipedia data because Perl would
throw an error. This change correctly escapes braces where necessary.